### PR TITLE
Harden `beframe-infer-frame-name` w.r.t. known project dirs (`project--list`)

### DIFF
--- a/beframe.el
+++ b/beframe.el
@@ -626,7 +626,9 @@ See `beframe-rename-frame'."
            (dir (with-current-buffer buffer (or (vc-root-dir) default-directory)))
            (projectp (and (bound-and-true-p project--list)
                           (listp project--list)
-                          (member (list dir) project--list))))
+                          (or
+                           (member (list dir) project--list)
+                           (member (list (abbreviate-file-name dir)) project--list)))))
       (cond
        ((and name (stringp name))
         name)


### PR DESCRIPTION
Hi @protesilaos 👋 

I believe I found a minor bug, and want to propose a fix for it.

In newer versions of Emacs, `project.el` [abbreviates local directory names](https://github.com/emacs-mirror/emacs/commit/255b7e1a046cbf9a745d58080d74983bfe205859) when it reads them into `project--list` from the file designated by `project-list-file`.

To illustrate, here are the contents of my local project list file, `~/.emacs.d/projects`:

```
;;; -*- lisp-data -*-
(("/Users/fritz/Development/emacs/tab-bar-echo-area/")
 ("/Users/fritz/Development/emacs/project-tab-groups/"))
```

And here are the contents of the `project--list` variable:

```
(("~/Development/emacs/tab-bar-echo-area/")
 ("~/Development/emacs/project-tab-groups/"))
```

In `beframe-infer-frame-name`, L626 assigns the directory name to match against the list of known projects to `dir`:

```
(let* ((buffer (car (frame-parameter frame 'buffer-list)))
       ...
       (dir (with-current-buffer buffer (or (vc-root-dir) default-directory)))
       ....
```

While `vc-root-dir` returns an abbreviated directory name (and thus successfully matches the abbreviated directory name in `project--list`), `default-directory` is not abbreviated.

This becomes an issue in buffers that can be considered to belong to a project, but do not visit a file (like `magit-status`, `xref`, etc.) -- for these, `vc-root-dir` seems to return `nil`, so `dir` references `default-directory`.

My suggested patch tries to find both the abbreviated and the non-abbreviated version of `dir` in `project--list`.

An alternative solution might have been to assign an abbreviated version of `default-directory` to `dir` in L626 already, but I believe that my version comes with the benefit of supporting older versions of Emacs, in which entries in `project--list` have not been abbreviated at all.

Please do double-check my rationale above: I've been fiddling with beframe for just an hour or so to see if I want to replace my own [project-tab-groups](https://github.com/fritzgrabo/project-tab-groups) package with it. There's a chance I misunderstood some details of it. It _is_ kind of surprising that you didn't run into this issue yourself 😅.

Let me know what you think! Thanks!