### PR TITLE
Correction of previous expected behaviour and proposal for refactored deleted function

### DIFF
--- a/README.org
+++ b/README.org
@@ -401,7 +401,8 @@ matters.
 
 + Author/maintainer :: Protesilaos Stavrou.
 
-+ Contributions to code or the manual :: Edgar Vincent, Tony Zorman.
++ Contributions to code or the manual :: Bruno Boal, Edgar Vincent,
+  Tony Zorman.
 
 + Ideas and/or user feedback :: Derek Passen, Karan Ahlawat, Karthik
   Chikmagalur, Valentino, duli.

--- a/beframe.el
+++ b/beframe.el
@@ -141,19 +141,18 @@ automatically, use `customize-set-variable' or `setopt' (Emacs
 
 The following values of ARG can be used:
 
-- nil or \\='public\\=' to consider the return value of the `buffer-list'
+- \\='public\\=' to consider the return value of the `buffer-list'
   function.
 
 - \\='global\\=' to consider the user-custom option in `beframe-global-buffers'
 
-ARG can be the symbol \\='public or nil for `buffer-list' return value."
+- nil or a frame object satisfying `frame-live-p' to consider the
+  \\='buffer-list\\=' parameter of either `selected-frame' or the given object."
   (pcase arg
-    ((or 'public (pred null))
-     (beframe--remove-internal-buffers (buffer-list)))
+    ('public (beframe--remove-internal-buffers (buffer-list)))
     ('global (beframe--global-buffers))
-    ((or (and 'frame (let frame nil))
-         (and (pred frame-live-p) (let frame arg)))
-     (beframe--remove-internal-buffers (frame-parameter frame 'buffer-list)))
+    ((or (pred null) (pred frame-live-p))
+     (beframe--remove-internal-buffers (frame-parameter arg 'buffer-list)))
     (_ (user-error "Wrong argument in `beframe--get-buffers' pcase"))))
 
 (cl-defun beframe-buffer-list (&optional frame &key sort)

--- a/beframe.el
+++ b/beframe.el
@@ -155,6 +155,20 @@ The following values of ARG can be used:
      (beframe--remove-internal-buffers (frame-parameter arg 'buffer-list)))
     (_ (user-error "Wrong argument in `beframe--get-buffers' pcase"))))
 
+
+(defun beframe--global-buffers ()
+  "Return list of `beframe-global-buffers' buffer objects."
+  (pcase-let* ((pub-buffs (beframe--get-buffers 'public))
+               (`(,str-re ,modes-lst)
+                (cl-loop for E in beframe-global-buffers
+                         if (stringp E) collect E into str
+                         else if (symbolp E) collect E into sym
+                         finally return (list (string-join str "\\|") sym))))
+    (cl-loop for b in pub-buffs
+             if (string-match-p str-re (buffer-name b)) collect b
+             else if (with-current-buffer b (derived-mode-p modes-lst))
+             collect b)))
+
 (cl-defun beframe-buffer-list (&optional frame &key sort)
   "Return list of buffers that are used by the current frame.
 With optional FRAME as an object that satisfies `framep', return


### PR DESCRIPTION
Apologies for the last commit, now the desired functionality of `beframe--get-buffers` should be OK. I also took the opportunity to recheck the behavior of the proposed `beframe--global-buffers` which I also accidentally deleted in the aforementioned commit (terrible!). I tested it and it LGTM now however your keen eye will tell. All the best!