### PR TITLE
Use the predicate in beframe-read-buffer

### DIFF
--- a/beframe.el
+++ b/beframe.el
@@ -313,10 +313,10 @@ CANDIDATES is a list of strings.  METADATA is described in
       (complete-with-action action candidates string pred))))
 
 ;;;###autoload
-(defun beframe-read-buffer (prompt &optional def require-match _predicate)
+(defun beframe-read-buffer (prompt &optional def require-match predicate)
   "The `read-buffer-function' that limits buffers to frames.
 PROMPT, DEF, REQUIRE-MATCH, and PREDICATE are the same as
-`read-buffer'.  The PREDICATE is ignored, however, to apply the
+`read-buffer'.  The PREDICATE is applied in addition to the
 per-frame filter."
   (let* ((buffers (beframe-buffer-names))
          (table (beframe-get-completion-table buffers '(category . buffer))))
@@ -324,7 +324,9 @@ per-frame filter."
      (format "%s%s" (beframe--propertize-prompt-prefix) prompt)
      table
      (lambda (buffer)
-       (beframe--read-buffer-p buffer buffers))
+       (and (beframe--read-buffer-p buffer buffers)
+            (or (not predicate)
+                (funcall predicate buffer))))
      require-match
      nil
      'beframe-history


### PR DESCRIPTION
This PR is a small update to use the predicate in `beframe-read-buffer`. Prior, calls to `read-buffer` that provided a predicate would not work as expected because the predicate was always ignored by `beframe-read-buffer`.

Here is an [example](https://github.com/emacs-mirror/emacs/blob/emacs-30.2/lisp/net/eww.el#L2269) in `eww` that provides a predicate.

This is an example to demonstrate the issue:

```emacs-lisp
(setq inhibit-splash-screen t)
(setq inhibit-startup-screen t)
(setq inhibit-startup-message t)

(package-install 'beframe) ; or (add-to-list 'load-path "/path/to/beframe")
(package-install 'mct)

(setq beframe-rename-function nil)
(beframe-mode 1)
(mct-mode 1)

(switch-to-buffer "buffer-a")
(switch-to-buffer "buffer-b")

(scratch-buffer)
(select-frame (make-frame))

(switch-to-buffer "buffer-c")
(switch-to-buffer "buffer-d")

(defun example-predicate (candidate)
  (let* ((name (if (consp candidate) (car candidate) candidate)))
    (string= name "buffer-c")))

(defun example-read-buffer ()
  (interactive)
  (read-buffer "Example " nil nil #'example-predicate))
```

The first frame has assumed buffers "buffer-a" and "buffer-b". The second frame has assumed buffers "buffer-c" and "buffer-d".

On the second frame, when calling `M-x example-read-buffer` we would expect the only completion candidate to be "buffer-c" per `example-predicate`. However, without the fix in this PR, we get all of the frame's candidates.
